### PR TITLE
Varnish 7+ does not like quotes around name

### DIFF
--- a/vcl_load.go
+++ b/vcl_load.go
@@ -9,7 +9,7 @@ import (
 // LoadVCL compiles and loads the VCL file from the given file.
 // See https://varnish-cache.org/docs/trunk/reference/varnish-cli.html#vcl-load-configname-filename-auto-cold-warm
 func (c *Client) LoadVCL(ctx context.Context, configname, filename string, mode VCLState) error {
-	args := []string{strconv.Quote(configname), strconv.Quote(filename), string(mode)}
+	args := []string{configname, strconv.Quote(filename), string(mode)}
 	resp, err := c.roundtrip.Execute(ctx, &Request{"vcl.load", args})
 	if err != nil {
 		return err


### PR DESCRIPTION
Hello,

great lib! thx. 
we are using varnish 7+ and stumbled over the fact that config names are not alowed to use `"` anymore 🥺

regards
helmut